### PR TITLE
Take version from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <artifactId>guestbook</artifactId>
 
     <properties>
+        <appengine.app.version>1</appengine.app.version>
         <appengine.target.version>1.7.3</appengine.target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -78,6 +79,14 @@
                 <version>2.3</version>
                 <configuration>
                     <archiveClasses>true</archiveClasses>
+                    <webResources>
+                        <!-- in order to interpolate version from pom into appengine-web.xml -->
+                        <resource>
+                            <directory>${basedir}/src/main/webapp/WEB-INF</directory>
+                            <filtering>true</filtering>
+                            <targetPath>WEB-INF</targetPath>
+                        </resource>
+                    </webResources>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
     <application>guestbook</application>
-    <version>1</version>
+    <version>${appengine.app.version}</version>
     <threadsafe>true</threadsafe>
 
     <system-properties>


### PR DESCRIPTION
Instead of maintaining version in both the pom and appengine-web.xml, take the version from the pom and interpolate it to the appengine-web.xml on build.
