### PR TITLE
Added missing datastore-index

### DIFF
--- a/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<datastore-indexes autoGenerate="true">
+    <datastore-index kind="Greeting" ancestor="true" source="manual">
+        <property name="date" direction="desc"/>
+    </datastore-index>
+</datastore-indexes>


### PR DESCRIPTION
If deployed directly as a new application, requests to / fail with the following error:

```
com.google.appengine.api.datastore.DatastoreNeedIndexException: no matching index found.
The suggested index for this query is:
    <datastore-index kind="Greeting" ancestor="true" source="manual">
        <property name="date" direction="desc"/>
    </datastore-index>


	at com.google.appengine.api.datastore.DatastoreApiHelper.translateError(DatastoreApiHelper.java:51)
	at com.google.appengine.api.datastore.DatastoreApiHelper$AsyncCallWrapper.convertException(DatastoreApiHelper.java:74)
	at com.google.appengine.api.utils.FutureWrapper.get(FutureWrapper.java:96)
	at com.google.appengine.api.utils.FutureWrapper.get(FutureWrapper.java:88)
	at com.google.appengine.api.datastore.FutureHelper.getInternal(FutureHelper.java:75)
	at com.google.appengine.api.datastore.FutureHelper.quietGet(FutureHelper.java:35)
	at com.google.appengine.api.datastore.BaseQueryResultsSource.getIndexList(BaseQueryResultsSource.java:152)
	at com.google.appengine.api.datastore.BaseQueryResultsSource.loadMoreEntities(BaseQueryResultsSource.java:181)
	at com.google.appengine.api.datastore.QueryResultIteratorImpl.ensureLoaded(QueryResultIteratorImpl.java:161)
	at com.google.appengine.api.datastore.QueryResultIteratorImpl.nextList(QueryResultIteratorImpl.java:115)
	at com.google.appengine.api.datastore.LazyList.forceResolveToIndex(LazyList.java:93)
	at com.google.appengine.api.datastore.LazyList.resolveToIndex(LazyList.java:73)
	at com.google.appengine.api.datastore.LazyList.resolveToIndex(LazyList.java:56)
	at com.google.appengine.api.datastore.LazyList.isEmpty(LazyList.java:260)
	at org.apache.jsp.guestbook_jsp._jspService(guestbook_jsp.java:105)
```